### PR TITLE
fix #92 and #114

### DIFF
--- a/bridge-core/src/main/java/gg/modl/minecraft/bridge/reporter/ModlBackendReplayUploader.java
+++ b/bridge-core/src/main/java/gg/modl/minecraft/bridge/reporter/ModlBackendReplayUploader.java
@@ -12,6 +12,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.logging.Logger;
 import java.io.InputStream;
@@ -59,9 +60,13 @@ public class ModlBackendReplayUploader {
     }
 
     public CompletableFuture<String> uploadAsync(File replayFile, String mcVersion) {
+        return uploadAsync(replayFile, mcVersion, null, null);
+    }
+
+    public CompletableFuture<String> uploadAsync(File replayFile, String mcVersion, UUID targetUuid, String targetName) {
         return CompletableFuture.supplyAsync(() -> {
             try {
-                InitResponse init = initUpload(replayFile, mcVersion);
+                InitResponse init = initUpload(replayFile, mcVersion, targetUuid, targetName);
                 uploadToStorage(replayFile, init.uploadUrl);
                 confirmUpload(init.replayId);
                 return init.replayId;
@@ -71,10 +76,16 @@ public class ModlBackendReplayUploader {
         });
     }
 
-    private InitResponse initUpload(File file, String mcVersion) throws Exception {
+    private InitResponse initUpload(File file, String mcVersion, UUID targetUuid, String targetName) throws Exception {
         JsonObject body = new JsonObject();
         body.addProperty("mcVersion", mcVersion);
         body.addProperty("fileSize", file.length());
+        if (targetUuid != null) {
+            body.addProperty("targetUuid", targetUuid.toString());
+        }
+        if (targetName != null && !targetName.isEmpty()) {
+            body.addProperty("targetName", targetName);
+        }
 
         HttpURLConnection connection = (HttpURLConnection) new URL(backendUrl + "/v1/minecraft/replays/upload").openConnection();
         try {

--- a/bridge-core/src/test/java/gg/modl/minecraft/bridge/reporter/ModlBackendReplayUploaderTest.java
+++ b/bridge-core/src/test/java/gg/modl/minecraft/bridge/reporter/ModlBackendReplayUploaderTest.java
@@ -1,5 +1,7 @@
 package gg.modl.minecraft.bridge.reporter;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import com.sun.net.httpserver.HttpServer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -11,6 +13,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
@@ -26,11 +29,13 @@ class ModlBackendReplayUploaderTest {
     void acceptsVersionedBackendBaseUrls() throws IOException, ExecutionException, InterruptedException {
         HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         List<String> observedPaths = new CopyOnWriteArrayList<>();
+        List<String> initBodies = new CopyOnWriteArrayList<>();
         int port = server.getAddress().getPort();
         String baseUrl = "http://127.0.0.1:" + port;
 
         server.createContext("/v1/minecraft/replays/upload", exchange -> {
             observedPaths.add(exchange.getRequestURI().getPath());
+            initBodies.add(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
             byte[] response = ("{\"replayId\":\"replay-123\",\"uploadUrl\":\"" + baseUrl + "/storage\"}")
                     .getBytes(StandardCharsets.UTF_8);
             exchange.sendResponseHeaders(200, response.length);
@@ -57,10 +62,11 @@ class ModlBackendReplayUploaderTest {
 
         try {
             File replayFile = Files.write(tempDir.resolve("sample.replay"), "replay".getBytes(StandardCharsets.UTF_8)).toFile();
+            UUID targetUuid = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
             ModlBackendReplayUploader uploader = new ModlBackendReplayUploader(
                     baseUrl + "/v2", "key", "panel.example.com", Logger.getLogger("test"));
 
-            String replayId = uploader.uploadAsync(replayFile, "1.21.11").get();
+            String replayId = uploader.uploadAsync(replayFile, "1.21.11", targetUuid, "modltarget").get();
 
             assertEquals("replay-123", replayId);
             assertEquals(List.of(
@@ -68,6 +74,12 @@ class ModlBackendReplayUploaderTest {
                     "/storage",
                     "/v1/minecraft/replays/confirm/replay-123"
             ), observedPaths);
+            assertEquals(1, initBodies.size());
+            JsonObject initBody = JsonParser.parseString(initBodies.get(0)).getAsJsonObject();
+            assertEquals("1.21.11", initBody.get("mcVersion").getAsString());
+            assertEquals(replayFile.length(), initBody.get("fileSize").getAsLong());
+            assertEquals(targetUuid.toString(), initBody.get("targetUuid").getAsString());
+            assertEquals("modltarget", initBody.get("targetName").getAsString());
         } finally {
             server.stop(0);
         }

--- a/platforms/spigot/src/main/java/gg/modl/minecraft/spigot/bridge/BridgeComponent.java
+++ b/platforms/spigot/src/main/java/gg/modl/minecraft/spigot/bridge/BridgeComponent.java
@@ -227,7 +227,7 @@ public class BridgeComponent extends AbstractBridgeComponent implements Listener
                                 return CompletableFuture.completedFuture(ReplayCaptureResult.error());
                             }
 
-                            return uploader.uploadAsync(replayFile, recordingConfig.mcVersion())
+                            return uploader.uploadAsync(replayFile, recordingConfig.mcVersion(), targetUuid, targetName)
                                     .thenApply(ReplayCaptureResult::ok)
                                     .whenComplete((replayId, ex) -> {
                                         if (ex != null) {
@@ -420,6 +420,25 @@ public class BridgeComponent extends AbstractBridgeComponent implements Listener
         return resolveBlockStateId(block, BridgeComponent::resolveModernBlockStateId, BridgeComponent::resolveLegacyBlockStateId);
     }
 
+    static int recordingDeltaMs(long nowMs, long recordingStartMs) {
+        long elapsedMs = nowMs - recordingStartMs;
+        if (elapsedMs <= 0L) {
+            return 0;
+        }
+        if (elapsedMs >= Integer.MAX_VALUE) {
+            return Integer.MAX_VALUE;
+        }
+        return (int) elapsedMs;
+    }
+
+    private int recordingDeltaMs(UUID playerId) {
+        if (packetRecorder == null) {
+            return 0;
+        }
+
+        return recordingDeltaMs(System.currentTimeMillis(), packetRecorder.getRecordingStartTime(playerId));
+    }
+
     private static int resolveModernBlockStateId(Object blockData) {
         try {
             Class<?> blockDataClass = Class.forName("org.bukkit.block.data.BlockData");
@@ -443,7 +462,7 @@ public class BridgeComponent extends AbstractBridgeComponent implements Listener
         Block block = event.getBlockPlaced();
         int stateId = resolveBlockStateId(block);
         recordingManager.enqueueEvent(player.getUniqueId(),
-                new BlockChangeEvent(0, block.getX(), (short) block.getY(), block.getZ(), stateId));
+                new BlockChangeEvent(recordingDeltaMs(player.getUniqueId()), block.getX(), (short) block.getY(), block.getZ(), stateId));
     }
 
     @SuppressWarnings("deprecation")
@@ -454,7 +473,7 @@ public class BridgeComponent extends AbstractBridgeComponent implements Listener
         Block block = event.getBlock();
         int previousStateId = resolveBlockStateId(block);
         recordingManager.enqueueEvent(player.getUniqueId(),
-                new BlockChangeEvent(0, block.getX(), (short) block.getY(), block.getZ(), previousStateId));
+                new BlockChangeEvent(recordingDeltaMs(player.getUniqueId()), block.getX(), (short) block.getY(), block.getZ(), previousStateId));
     }
 
     @EventHandler

--- a/platforms/spigot/src/test/java/gg/modl/minecraft/spigot/bridge/BridgeComponentTest.java
+++ b/platforms/spigot/src/test/java/gg/modl/minecraft/spigot/bridge/BridgeComponentTest.java
@@ -60,4 +60,19 @@ class BridgeComponentTest {
         verify(block).getType();
         verify(block).getData();
     }
+
+    @Test
+    void recordingDeltaMsReturnsElapsedTimeSinceRecordingStarted() {
+        assertEquals(2500, BridgeComponent.recordingDeltaMs(12_500L, 10_000L));
+    }
+
+    @Test
+    void recordingDeltaMsClampsNegativeElapsedTimeToZero() {
+        assertEquals(0, BridgeComponent.recordingDeltaMs(9_500L, 10_000L));
+    }
+
+    @Test
+    void recordingDeltaMsClampsElapsedTimeAboveIntegerMaxValue() {
+        assertEquals(Integer.MAX_VALUE, BridgeComponent.recordingDeltaMs(Integer.MAX_VALUE + 2L, 0L));
+    }
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Confidence Score: 3/5</h3>

This should be fixed before merging.

- Block place and break handlers can now query recording start time for players who are not recording.
- That can make normal block interactions fail or produce invalid replay timestamps when replay support is enabled.
- Uploaded replay names can come from stale request metadata instead of the local online player.

platforms/spigot/src/main/java/gg/modl/minecraft/spigot/bridge/BridgeComponent.java

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| bridge-core/src/main/java/gg/modl/minecraft/bridge/reporter/ModlBackendReplayUploader.java | Adds optional replay target fields to the backend upload init payload. |
| platforms/spigot/src/main/java/gg/modl/minecraft/spigot/bridge/BridgeComponent.java | Forwards replay target metadata and changes block replay event timestamps to use recording elapsed time. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Aplatforms%2Fspigot%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Fspigot%2Fbridge%2FBridgeComponent.java%3A460-465%0A**Guard%20active%20recordings**%0A%0AThis%20handler%20now%20computes%20the%20timestamp%20before%20handing%20the%20event%20to%20%60recordingManager.enqueueEvent%60%2C%20but%20it%20only%20checks%20that%20the%20manager%20exists.%20When%20replay%20support%20is%20enabled%20and%20a%20non-recorded%20player%20places%20a%20block%2C%20%60recordingDeltaMs%28player.getUniqueId%28%29%29%60%20still%20calls%20%60packetRecorder.getRecordingStartTime%28playerId%29%60%20for%20a%20player%20with%20no%20active%20recording.%20That%20can%20fail%20while%20looking%20up%20the%20active%20recording%2C%20or%20produce%20a%20bogus%20clamped%20timestamp%2C%20before%20the%20manager%20can%20ignore%20the%20event.%20Add%20an%20%60isRecording%60%20guard%20before%20computing%20the%20delta.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20%28recordingManager%20%3D%3D%20null%29%20return%3B%0A%20%20%20%20%20%20%20%20Player%20player%20%3D%20event.getPlayer%28%29%3B%0A%20%20%20%20%20%20%20%20if%20%28!recordingManager.isRecording%28player.getUniqueId%28%29%29%29%20return%3B%0A%20%20%20%20%20%20%20%20Block%20block%20%3D%20event.getBlockPlaced%28%29%3B%0A%20%20%20%20%20%20%20%20int%20stateId%20%3D%20resolveBlockStateId%28block%29%3B%0A%20%20%20%20%20%20%20%20recordingManager.enqueueEvent%28player.getUniqueId%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20new%20BlockChangeEvent%28recordingDeltaMs%28player.getUniqueId%28%29%29%2C%20block.getX%28%29%2C%20%28short%29%20block.getY%28%29%2C%20block.getZ%28%29%2C%20stateId%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Aplatforms%2Fspigot%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Fspigot%2Fbridge%2FBridgeComponent.java%3A471-476%0A**Guard%20active%20recordings**%0A%0AThis%20path%20has%20the%20same%20timestamp%20lookup%20for%20every%20block%20break%20while%20replay%20support%20is%20initialized.%20A%20player%20who%20is%20not%20currently%20recording%20can%20still%20reach%20%60recordingDeltaMs%28player.getUniqueId%28%29%29%60%2C%20which%20asks%20%60packetRecorder%60%20for%20a%20recording%20start%20time%20before%20%60enqueueEvent%60%20can%20drop%20the%20event.%20That%20makes%20ordinary%20block%20breaks%20by%20non-recorded%20players%20able%20to%20fail%20or%20create%20invalid%20event%20timestamps.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20%28recordingManager%20%3D%3D%20null%29%20return%3B%0A%20%20%20%20%20%20%20%20Player%20player%20%3D%20event.getPlayer%28%29%3B%0A%20%20%20%20%20%20%20%20if%20%28!recordingManager.isRecording%28player.getUniqueId%28%29%29%29%20return%3B%0A%20%20%20%20%20%20%20%20Block%20block%20%3D%20event.getBlock%28%29%3B%0A%20%20%20%20%20%20%20%20int%20previousStateId%20%3D%20resolveBlockStateId%28block%29%3B%0A%20%20%20%20%20%20%20%20recordingManager.enqueueEvent%28player.getUniqueId%28%29%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20new%20BlockChangeEvent%28recordingDeltaMs%28player.getUniqueId%28%29%29%2C%20block.getX%28%29%2C%20%28short%29%20block.getY%28%29%2C%20block.getZ%28%29%2C%20previousStateId%29%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%203%20of%203%0Aplatforms%2Fspigot%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Fspigot%2Fbridge%2FBridgeComponent.java%3A230%0A**Use%20local%20player%20name**%0A%0AThe%20upload%20metadata%20now%20trusts%20the%20%60targetName%60%20string%20passed%20through%20the%20replay%20request%2C%20even%20though%20the%20Spigot%20side%20has%20the%20authoritative%20online%20player%20for%20%60targetUuid%60.%20If%20the%20bridge%20message%20carries%20an%20empty%20or%20stale%20name%2C%20the%20backend%20replay%20is%20uploaded%20with%20the%20wrong%20%60targetName%60%20while%20the%20recording%20itself%20is%20for%20the%20correct%20UUID.%20Resolve%20the%20current%20Bukkit%20player%20name%20before%20upload%20when%20available.%0A%0A&repo=modl-gg%2Fminecraft&pr=12&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
platforms/spigot/src/main/java/gg/modl/minecraft/spigot/bridge/BridgeComponent.java:460-465
**Guard active recordings**

This handler now computes the timestamp before handing the event to `recordingManager.enqueueEvent`, but it only checks that the manager exists. When replay support is enabled and a non-recorded player places a block, `recordingDeltaMs(player.getUniqueId())` still calls `packetRecorder.getRecordingStartTime(playerId)` for a player with no active recording. That can fail while looking up the active recording, or produce a bogus clamped timestamp, before the manager can ignore the event. Add an `isRecording` guard before computing the delta.

```suggestion
        if (recordingManager == null) return;
        Player player = event.getPlayer();
        if (!recordingManager.isRecording(player.getUniqueId())) return;
        Block block = event.getBlockPlaced();
        int stateId = resolveBlockStateId(block);
        recordingManager.enqueueEvent(player.getUniqueId(),
                new BlockChangeEvent(recordingDeltaMs(player.getUniqueId()), block.getX(), (short) block.getY(), block.getZ(), stateId));
```

### Issue 2 of 3
platforms/spigot/src/main/java/gg/modl/minecraft/spigot/bridge/BridgeComponent.java:471-476
**Guard active recordings**

This path has the same timestamp lookup for every block break while replay support is initialized. A player who is not currently recording can still reach `recordingDeltaMs(player.getUniqueId())`, which asks `packetRecorder` for a recording start time before `enqueueEvent` can drop the event. That makes ordinary block breaks by non-recorded players able to fail or create invalid event timestamps.

```suggestion
        if (recordingManager == null) return;
        Player player = event.getPlayer();
        if (!recordingManager.isRecording(player.getUniqueId())) return;
        Block block = event.getBlock();
        int previousStateId = resolveBlockStateId(block);
        recordingManager.enqueueEvent(player.getUniqueId(),
                new BlockChangeEvent(recordingDeltaMs(player.getUniqueId()), block.getX(), (short) block.getY(), block.getZ(), previousStateId));
```

### Issue 3 of 3
platforms/spigot/src/main/java/gg/modl/minecraft/spigot/bridge/BridgeComponent.java:230
**Use local player name**

The upload metadata now trusts the `targetName` string passed through the replay request, even though the Spigot side has the authoritative online player for `targetUuid`. If the bridge message carries an empty or stale name, the backend replay is uploaded with the wrong `targetName` while the recording itself is for the correct UUID. Resolve the current Bukkit player name before upload when available.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix #92 and #114"](https://github.com/modl-gg/minecraft/commit/781b2031c2f4059d0fd44be66bde3d155dbd4d19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32589949)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->