### PR TITLE
Fix unvanish skin layers and mod crashes by using vanilla entity trac…

### DIFF
--- a/platforms/fabric-121/src/main/java/gg/modl/minecraft/fabric/v1_21_1/handler/FabricStaffModeHandler.java
+++ b/platforms/fabric-121/src/main/java/gg/modl/minecraft/fabric/v1_21_1/handler/FabricStaffModeHandler.java
@@ -21,6 +21,8 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import net.minecraft.world.GameMode;
+import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
+import net.minecraft.server.network.EntityTrackerEntry;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -186,47 +188,22 @@ public class FabricStaffModeHandler {
     }
 
     private void showPlayerTo(ServerPlayerEntity toShow, ServerPlayerEntity viewer) {
-        var peApi = PacketEvents.getAPI();
-        if (peApi == null) return;
-
-        com.mojang.authlib.GameProfile mojangProfile = toShow.getGameProfile();
-        List<TextureProperty> textureProperties = new ArrayList<>();
-        for (com.mojang.authlib.properties.Property prop : mojangProfile.getProperties().get("textures")) {
-            textureProperties.add(new TextureProperty("textures", prop.value(), prop.signature()));
+        if (toShow == null || viewer == null || toShow == viewer) {
+            return;
         }
-        UserProfile profile = new UserProfile(toShow.getUuid(), mojangProfile.getName(), textureProperties);
 
-        com.github.retrooper.packetevents.protocol.player.GameMode peGameMode =
-                com.github.retrooper.packetevents.protocol.player.GameMode.values()[toShow.interactionManager.getGameMode().ordinal()];
+        viewer.networkHandler.sendPacket(PlayerListS2CPacket.entryFromPlayer(List.of(toShow)));
 
-        WrapperPlayServerPlayerInfoUpdate.PlayerInfo info = new WrapperPlayServerPlayerInfoUpdate.PlayerInfo(
-                profile, true, toShow.networkHandler.getLatency(), peGameMode,
-                net.kyori.adventure.text.Component.text(toShow.getName().getString()), null
+        EntityTrackerEntry trackerEntry = new EntityTrackerEntry(
+                toShow.getServerWorld(),
+                toShow,
+                toShow.getType().getTrackTickInterval(),
+                toShow.getType().alwaysUpdateVelocity(),
+                packet -> {
+                }
         );
 
-        peApi.getPlayerManager().sendPacket(viewer,
-                new WrapperPlayServerPlayerInfoUpdate(
-                        EnumSet.of(
-                                WrapperPlayServerPlayerInfoUpdate.Action.ADD_PLAYER,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LISTED,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LATENCY,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_GAME_MODE
-                        ),
-                        info
-                ));
-
-        peApi.getPlayerManager().sendPacket(viewer,
-                new WrapperPlayServerSpawnEntity(
-                        toShow.getId(),
-                        Optional.of(toShow.getUuid()),
-                        EntityTypes.PLAYER,
-                        new Vector3d(toShow.getX(), toShow.getY(), toShow.getZ()),
-                        toShow.getPitch(),
-                        toShow.getYaw(),
-                        toShow.getYaw(),
-                        0,
-                        Optional.of(new Vector3d(0, 0, 0))
-                ));
+        trackerEntry.sendPackets(viewer, packet -> viewer.networkHandler.sendPacket(packet));
     }
 
     private void updateVanishHotbarItem(ServerPlayerEntity player, boolean isVanished) {

--- a/platforms/fabric-12111/src/main/java/gg/modl/minecraft/fabric/v1_21_11/handler/FabricStaffModeHandler.java
+++ b/platforms/fabric-12111/src/main/java/gg/modl/minecraft/fabric/v1_21_11/handler/FabricStaffModeHandler.java
@@ -15,8 +15,12 @@ import lombok.Setter;
 import net.kyori.adventure.text.Component;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.network.listener.ClientPlayPacketListener;
+import net.minecraft.network.packet.Packet;
+import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.registry.Registries;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.EntityTrackerEntry;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
@@ -26,6 +30,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static gg.modl.minecraft.core.util.Java8Collections.*;
@@ -184,47 +189,36 @@ public class FabricStaffModeHandler {
     }
 
     private void showPlayerTo(ServerPlayerEntity toShow, ServerPlayerEntity viewer) {
-        var peApi = PacketEvents.getAPI();
-        if (peApi == null) return;
-
-        com.mojang.authlib.GameProfile mojangProfile = toShow.getGameProfile();
-        List<TextureProperty> textureProperties = new ArrayList<>();
-        for (com.mojang.authlib.properties.Property prop : mojangProfile.properties().get("textures")) {
-            textureProperties.add(new TextureProperty("textures", prop.value(), prop.signature()));
+        if (toShow == null || viewer == null || toShow == viewer) {
+            return;
         }
-        UserProfile profile = new UserProfile(toShow.getUuid(), mojangProfile.name(), textureProperties);
 
-        com.github.retrooper.packetevents.protocol.player.GameMode peGameMode =
-                com.github.retrooper.packetevents.protocol.player.GameMode.values()[toShow.interactionManager.getGameMode().ordinal()];
+        viewer.networkHandler.sendPacket(PlayerListS2CPacket.entryFromPlayer(List.of(toShow)));
 
-        WrapperPlayServerPlayerInfoUpdate.PlayerInfo info = new WrapperPlayServerPlayerInfoUpdate.PlayerInfo(
-                profile, true, toShow.networkHandler.getLatency(), peGameMode,
-                net.kyori.adventure.text.Component.text(toShow.getName().getString()), null
+        EntityTrackerEntry trackerEntry = new EntityTrackerEntry(
+                toShow.getEntityWorld(),
+                toShow,
+                toShow.getType().getTrackTickInterval(),
+                toShow.getType().alwaysUpdateVelocity(),
+                new EntityTrackerEntry.TrackerPacketSender() {
+                    @Override
+                    public void sendToListeners(Packet<? super ClientPlayPacketListener> packet) {
+                    }
+
+                    @Override
+                    public void sendToSelfAndListeners(Packet<? super ClientPlayPacketListener> packet) {
+                    }
+
+                    @Override
+                    public void sendToListenersIf(
+                            Packet<? super ClientPlayPacketListener> packet,
+                            Predicate<ServerPlayerEntity> predicate
+                    ) {
+                    }
+                }
         );
 
-        peApi.getPlayerManager().sendPacket(viewer,
-                new WrapperPlayServerPlayerInfoUpdate(
-                        EnumSet.of(
-                                WrapperPlayServerPlayerInfoUpdate.Action.ADD_PLAYER,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LISTED,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LATENCY,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_GAME_MODE
-                        ),
-                        info
-                ));
-
-        peApi.getPlayerManager().sendPacket(viewer,
-                new WrapperPlayServerSpawnEntity(
-                        toShow.getId(),
-                        Optional.of(toShow.getUuid()),
-                        EntityTypes.PLAYER,
-                        new Vector3d(toShow.getX(), toShow.getY(), toShow.getZ()),
-                        toShow.getPitch(),
-                        toShow.getYaw(),
-                        toShow.getYaw(),
-                        0,
-                        Optional.of(new Vector3d(0, 0, 0))
-                ));
+        trackerEntry.sendPackets(viewer, packet -> viewer.networkHandler.sendPacket(packet));
     }
 
     private void updateVanishHotbarItem(ServerPlayerEntity player, boolean isVanished) {

--- a/platforms/fabric-1214/src/main/java/gg/modl/minecraft/fabric/v1_21_4/handler/FabricStaffModeHandler.java
+++ b/platforms/fabric-1214/src/main/java/gg/modl/minecraft/fabric/v1_21_4/handler/FabricStaffModeHandler.java
@@ -15,8 +15,10 @@ import lombok.Setter;
 import net.kyori.adventure.text.Component;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.registry.Registries;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.EntityTrackerEntry;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
@@ -183,48 +185,24 @@ public class FabricStaffModeHandler {
                 new WrapperPlayServerDestroyEntities(toHide.getId()));
     }
 
+
     private void showPlayerTo(ServerPlayerEntity toShow, ServerPlayerEntity viewer) {
-        var peApi = PacketEvents.getAPI();
-        if (peApi == null) return;
-
-        com.mojang.authlib.GameProfile mojangProfile = toShow.getGameProfile();
-        List<TextureProperty> textureProperties = new ArrayList<>();
-        for (com.mojang.authlib.properties.Property prop : mojangProfile.getProperties().get("textures")) {
-            textureProperties.add(new TextureProperty("textures", prop.value(), prop.signature()));
+        if (toShow == null || viewer == null || toShow == viewer) {
+            return;
         }
-        UserProfile profile = new UserProfile(toShow.getUuid(), mojangProfile.getName(), textureProperties);
 
-        com.github.retrooper.packetevents.protocol.player.GameMode peGameMode =
-                com.github.retrooper.packetevents.protocol.player.GameMode.values()[toShow.interactionManager.getGameMode().ordinal()];
+        viewer.networkHandler.sendPacket(PlayerListS2CPacket.entryFromPlayer(List.of(toShow)));
 
-        WrapperPlayServerPlayerInfoUpdate.PlayerInfo info = new WrapperPlayServerPlayerInfoUpdate.PlayerInfo(
-                profile, true, toShow.networkHandler.getLatency(), peGameMode,
-                net.kyori.adventure.text.Component.text(toShow.getName().getString()), null
+        EntityTrackerEntry trackerEntry = new EntityTrackerEntry(
+                toShow.getServerWorld(),
+                toShow,
+                toShow.getType().getTrackTickInterval(),
+                toShow.getType().alwaysUpdateVelocity(),
+                packet -> {
+                }
         );
 
-        peApi.getPlayerManager().sendPacket(viewer,
-                new WrapperPlayServerPlayerInfoUpdate(
-                        EnumSet.of(
-                                WrapperPlayServerPlayerInfoUpdate.Action.ADD_PLAYER,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LISTED,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LATENCY,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_GAME_MODE
-                        ),
-                        info
-                ));
-
-        peApi.getPlayerManager().sendPacket(viewer,
-                new WrapperPlayServerSpawnEntity(
-                        toShow.getId(),
-                        Optional.of(toShow.getUuid()),
-                        EntityTypes.PLAYER,
-                        new Vector3d(toShow.getX(), toShow.getY(), toShow.getZ()),
-                        toShow.getPitch(),
-                        toShow.getYaw(),
-                        toShow.getYaw(),
-                        0,
-                        Optional.of(new Vector3d(0, 0, 0))
-                ));
+        trackerEntry.sendPackets(viewer, packet -> viewer.networkHandler.sendPacket(packet));
     }
 
     private void updateVanishHotbarItem(ServerPlayerEntity player, boolean isVanished) {

--- a/platforms/fabric-1218/src/main/java/gg/modl/minecraft/fabric/v1_21_8/handler/FabricStaffModeHandler.java
+++ b/platforms/fabric-1218/src/main/java/gg/modl/minecraft/fabric/v1_21_8/handler/FabricStaffModeHandler.java
@@ -15,8 +15,10 @@ import lombok.Setter;
 import net.kyori.adventure.text.Component;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
+import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.registry.Registries;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.EntityTrackerEntry;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
@@ -183,49 +185,72 @@ public class FabricStaffModeHandler {
                 new WrapperPlayServerDestroyEntities(toHide.getId()));
     }
 
+
+
     private void showPlayerTo(ServerPlayerEntity toShow, ServerPlayerEntity viewer) {
-        var peApi = PacketEvents.getAPI();
-        if (peApi == null) return;
-
-        com.mojang.authlib.GameProfile mojangProfile = toShow.getGameProfile();
-        List<TextureProperty> textureProperties = new ArrayList<>();
-        for (com.mojang.authlib.properties.Property prop : mojangProfile.getProperties().get("textures")) {
-            textureProperties.add(new TextureProperty("textures", prop.value(), prop.signature()));
+        if (toShow == null || viewer == null || toShow == viewer) {
+            return;
         }
-        UserProfile profile = new UserProfile(toShow.getUuid(), mojangProfile.getName(), textureProperties);
 
-        com.github.retrooper.packetevents.protocol.player.GameMode peGameMode =
-                com.github.retrooper.packetevents.protocol.player.GameMode.values()[toShow.interactionManager.getGameMode().ordinal()];
+        viewer.networkHandler.sendPacket(PlayerListS2CPacket.entryFromPlayer(List.of(toShow)));
 
-        WrapperPlayServerPlayerInfoUpdate.PlayerInfo info = new WrapperPlayServerPlayerInfoUpdate.PlayerInfo(
-                profile, true, toShow.networkHandler.getLatency(), peGameMode,
-                net.kyori.adventure.text.Component.text(toShow.getName().getString()), null
+        EntityTrackerEntry trackerEntry = new EntityTrackerEntry(
+                toShow.getWorld(),
+                toShow,
+                toShow.getType().getTrackTickInterval(),
+                toShow.getType().alwaysUpdateVelocity(),
+                packet -> {},
+                (packet, excludedPlayers) -> {
+
+                }
         );
 
-        peApi.getPlayerManager().sendPacket(viewer,
-                new WrapperPlayServerPlayerInfoUpdate(
-                        EnumSet.of(
-                                WrapperPlayServerPlayerInfoUpdate.Action.ADD_PLAYER,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LISTED,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LATENCY,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_GAME_MODE
-                        ),
-                        info
-                ));
-
-        peApi.getPlayerManager().sendPacket(viewer,
-                new WrapperPlayServerSpawnEntity(
-                        toShow.getId(),
-                        Optional.of(toShow.getUuid()),
-                        EntityTypes.PLAYER,
-                        new Vector3d(toShow.getX(), toShow.getY(), toShow.getZ()),
-                        toShow.getPitch(),
-                        toShow.getYaw(),
-                        toShow.getYaw(),
-                        0,
-                        Optional.of(new Vector3d(0, 0, 0))
-                ));
+        trackerEntry.sendPackets(viewer, packet -> viewer.networkHandler.sendPacket(packet));
     }
+
+//    private void showPlayerTo(ServerPlayerEntity toShow, ServerPlayerEntity viewer) {
+//        var peApi = PacketEvents.getAPI();
+//        if (peApi == null) return;
+//
+//        com.mojang.authlib.GameProfile mojangProfile = toShow.getGameProfile();
+//        List<TextureProperty> textureProperties = new ArrayList<>();
+//        for (com.mojang.authlib.properties.Property prop : mojangProfile.getProperties().get("textures")) {
+//            textureProperties.add(new TextureProperty("textures", prop.value(), prop.signature()));
+//        }
+//        UserProfile profile = new UserProfile(toShow.getUuid(), mojangProfile.getName(), textureProperties);
+//
+//        com.github.retrooper.packetevents.protocol.player.GameMode peGameMode =
+//                com.github.retrooper.packetevents.protocol.player.GameMode.values()[toShow.interactionManager.getGameMode().ordinal()];
+//
+//        WrapperPlayServerPlayerInfoUpdate.PlayerInfo info = new WrapperPlayServerPlayerInfoUpdate.PlayerInfo(
+//                profile, true, toShow.networkHandler.getLatency(), peGameMode,
+//                net.kyori.adventure.text.Component.text(toShow.getName().getString()), null
+//        );
+//
+//        peApi.getPlayerManager().sendPacket(viewer,
+//                new WrapperPlayServerPlayerInfoUpdate(
+//                        EnumSet.of(
+//                                WrapperPlayServerPlayerInfoUpdate.Action.ADD_PLAYER,
+//                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LISTED,
+//                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LATENCY,
+//                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_GAME_MODE
+//                        ),
+//                        info
+//                ));
+//
+//        peApi.getPlayerManager().sendPacket(viewer,
+//                new WrapperPlayServerSpawnEntity(
+//                        toShow.getId(),
+//                        Optional.of(toShow.getUuid()),
+//                        EntityTypes.PLAYER,
+//                        new Vector3d(toShow.getX(), toShow.getY(), toShow.getZ()),
+//                        toShow.getPitch(),
+//                        toShow.getYaw(),
+//                        toShow.getYaw(),
+//                        0,
+//                        Optional.of(new Vector3d(0, 0, 0))
+//                ));
+//    }
 
     private void updateVanishHotbarItem(ServerPlayerEntity player, boolean isVanished) {
         Map<Integer, StaffModeConfig.HotbarItem> hotbar = getActiveHotbar(player.getUuid());

--- a/platforms/fabric-26/src/main/java/gg/modl/minecraft/fabric/v26/handler/FabricStaffModeHandler.java
+++ b/platforms/fabric-26/src/main/java/gg/modl/minecraft/fabric/v26/handler/FabricStaffModeHandler.java
@@ -22,8 +22,12 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.Packet;
+import net.minecraft.network.protocol.game.ClientGamePacketListener;
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerEntity;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Container;
@@ -54,6 +58,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static gg.modl.minecraft.core.util.Java8Collections.mapOf;
@@ -215,51 +220,41 @@ public class FabricStaffModeHandler {
     }
 
     private void showPlayerTo(ServerPlayer toShow, ServerPlayer viewer) {
-        var peApi = PacketEvents.getAPI();
-        if (peApi == null) {
+        if (toShow == null || viewer == null || toShow == viewer) {
             return;
         }
 
-        com.mojang.authlib.GameProfile mojangProfile = toShow.getGameProfile();
-        List<TextureProperty> textureProperties = new ArrayList<>();
-        for (com.mojang.authlib.properties.Property property : mojangProfile.properties().get("textures")) {
-            textureProperties.add(new TextureProperty("textures", property.value(), property.signature()));
-        }
-        UserProfile profile = new UserProfile(toShow.getUUID(), mojangProfile.name(), textureProperties);
+        viewer.connection.send(
 
-        com.github.retrooper.packetevents.protocol.player.GameMode peGameMode =
-                com.github.retrooper.packetevents.protocol.player.GameMode.values()[
-                        toShow.gameMode.getGameModeForPlayer().ordinal()];
+                ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(List.of(toShow))
+        );
 
-        WrapperPlayServerPlayerInfoUpdate.PlayerInfo info =
-                new WrapperPlayServerPlayerInfoUpdate.PlayerInfo(
-                        profile, true, toShow.connection.latency(), peGameMode,
-                        net.kyori.adventure.text.Component.text(toShow.getName().getString()), null
-                );
+        ServerEntity trackerEntry = new ServerEntity(
+                toShow.level(),
+                toShow,
+                toShow.getType().updateInterval(),
+                toShow.getType().trackDeltas(),
+                new ServerEntity.Synchronizer() {
+                    @Override
+                    public void sendToTrackingPlayers(Packet<? super ClientGamePacketListener> packet) {
+                    }
 
-        peApi.getPlayerManager().sendPacket(viewer,
-                new WrapperPlayServerPlayerInfoUpdate(
-                        EnumSet.of(
-                                WrapperPlayServerPlayerInfoUpdate.Action.ADD_PLAYER,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LISTED,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_LATENCY,
-                                WrapperPlayServerPlayerInfoUpdate.Action.UPDATE_GAME_MODE
-                        ),
-                        info
-                ));
+                    @Override
+                    public void sendToTrackingPlayersAndSelf(Packet<? super ClientGamePacketListener> packet) {
+                    }
 
-        peApi.getPlayerManager().sendPacket(viewer,
-                new WrapperPlayServerSpawnEntity(
-                        toShow.getId(),
-                        Optional.of(toShow.getUUID()),
-                        EntityTypes.PLAYER,
-                        new Vector3d(toShow.getX(), toShow.getY(), toShow.getZ()),
-                        toShow.getXRot(),
-                        toShow.getYRot(),
-                        toShow.getYRot(),
-                        0,
-                        Optional.of(new Vector3d(0, 0, 0))
-                ));
+
+                    @Override
+                    public void sendToTrackingPlayersFiltered(
+                            Packet<? super ClientGamePacketListener> packet,
+                            Predicate<ServerPlayer> predicate
+                    ) {
+                    }
+                }
+        );
+
+        trackerEntry.sendPairingData(viewer,packet -> viewer.connection.send(packet)
+        );
     }
 
     private void updateVanishHotbarItem(ServerPlayer player, boolean isVanished) {


### PR DESCRIPTION
…ker packets

<!-- greptile_comment -->

<h3>Confidence Score: 3/5</h3>

This should be fixed before merging.

- The changed unvanish path can send entity pairing packets to viewers who should not track that player.
- The same issue is copied across all changed Fabric adapters.
- The normal vanilla same-world and tracking-distance checks are bypassed by the direct packet send.

All changed `FabricStaffModeHandler` versions need the same tracking eligibility guard.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| platforms/fabric-121/src/main/java/gg/modl/minecraft/fabric/v1_21_1/handler/FabricStaffModeHandler.java | Switches unvanish re-show packets to vanilla player-list and tracker pairing data. |
| platforms/fabric-1214/src/main/java/gg/modl/minecraft/fabric/v1_21_4/handler/FabricStaffModeHandler.java | Applies the same vanilla tracker re-show path for Minecraft 1.21.4. |
| platforms/fabric-1218/src/main/java/gg/modl/minecraft/fabric/v1_21_8/handler/FabricStaffModeHandler.java | Adds the 1.21.8 tracker constructor variant for the re-show path. |
| platforms/fabric-12111/src/main/java/gg/modl/minecraft/fabric/v1_21_11/handler/FabricStaffModeHandler.java | Adds the 1.21.11 tracker sender implementation for the re-show path. |
| platforms/fabric-26/src/main/java/gg/modl/minecraft/fabric/v26/handler/FabricStaffModeHandler.java | Uses Mojang-mapped player-info and `ServerEntity` pairing data for the re-show path. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%205%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%205%0Aplatforms%2Ffabric-121%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Ffabric%2Fv1_21_1%2Fhandler%2FFabricStaffModeHandler.java%3A195-206%0A**Unconditional%20tracker%20pairing**%0A%0A%60unvanish%28%29%60%20calls%20this%20for%20every%20online%20player%2C%20but%20this%20new%20vanilla-packet%20path%20sends%20player-list%20and%20tracker%20pairing%20data%20without%20checking%20that%20the%20viewer%20is%20in%20the%20same%20world%20or%20inside%20the%20normal%20tracking%20range.%20If%20a%20vanished%20staff%20member%20unvanishes%20in%20another%20dimension%20or%20far%20away%2C%20this%20can%20spawn%20a%20ghost%20player%20entity%20for%20viewers%20who%20vanilla%20tracking%20would%20not%20pair%20with%20at%20all.%20Gate%20this%20send%20through%20the%20same%20world%2Frange%20conditions%2C%20or%20use%20the%20real%20server%20tracker%E2%80%99s%20pairing%20decision%20instead%20of%20sending%20a%20fresh%20tracker%20entry%20to%20every%20viewer.%0A%0A%23%23%23%20Issue%202%20of%205%0Aplatforms%2Ffabric-1214%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Ffabric%2Fv1_21_4%2Fhandler%2FFabricStaffModeHandler.java%3A194-205%0A**Unconditional%20tracker%20pairing**%0A%0A%60unvanish%28%29%60%20calls%20this%20for%20every%20online%20player%2C%20but%20this%20new%20vanilla-packet%20path%20sends%20player-list%20and%20tracker%20pairing%20data%20without%20checking%20that%20the%20viewer%20is%20in%20the%20same%20world%20or%20inside%20the%20normal%20tracking%20range.%20If%20a%20vanished%20staff%20member%20unvanishes%20in%20another%20dimension%20or%20far%20away%2C%20this%20can%20spawn%20a%20ghost%20player%20entity%20for%20viewers%20who%20vanilla%20tracking%20would%20not%20pair%20with%20at%20all.%20Gate%20this%20send%20through%20the%20same%20world%2Frange%20conditions%2C%20or%20use%20the%20real%20server%20tracker%E2%80%99s%20pairing%20decision%20instead%20of%20sending%20a%20fresh%20tracker%20entry%20to%20every%20viewer.%0A%0A%23%23%23%20Issue%203%20of%205%0Aplatforms%2Ffabric-1218%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Ffabric%2Fv1_21_8%2Fhandler%2FFabricStaffModeHandler.java%3A195-208%0A**Unconditional%20tracker%20pairing**%0A%0A%60unvanish%28%29%60%20calls%20this%20for%20every%20online%20player%2C%20but%20this%20new%20vanilla-packet%20path%20sends%20player-list%20and%20tracker%20pairing%20data%20without%20checking%20that%20the%20viewer%20is%20in%20the%20same%20world%20or%20inside%20the%20normal%20tracking%20range.%20If%20a%20vanished%20staff%20member%20unvanishes%20in%20another%20dimension%20or%20far%20away%2C%20this%20can%20spawn%20a%20ghost%20player%20entity%20for%20viewers%20who%20vanilla%20tracking%20would%20not%20pair%20with%20at%20all.%20Gate%20this%20send%20through%20the%20same%20world%2Frange%20conditions%2C%20or%20use%20the%20real%20server%20tracker%E2%80%99s%20pairing%20decision%20instead%20of%20sending%20a%20fresh%20tracker%20entry%20to%20every%20viewer.%0A%0A%23%23%23%20Issue%204%20of%205%0Aplatforms%2Ffabric-12111%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Ffabric%2Fv1_21_11%2Fhandler%2FFabricStaffModeHandler.java%3A196-221%0A**Unconditional%20tracker%20pairing**%0A%0A%60unvanish%28%29%60%20calls%20this%20for%20every%20online%20player%2C%20but%20this%20new%20vanilla-packet%20path%20sends%20player-list%20and%20tracker%20pairing%20data%20without%20checking%20that%20the%20viewer%20is%20in%20the%20same%20world%20or%20inside%20the%20normal%20tracking%20range.%20If%20a%20vanished%20staff%20member%20unvanishes%20in%20another%20dimension%20or%20far%20away%2C%20this%20can%20spawn%20a%20ghost%20player%20entity%20for%20viewers%20who%20vanilla%20tracking%20would%20not%20pair%20with%20at%20all.%20Gate%20this%20send%20through%20the%20same%20world%2Frange%20conditions%2C%20or%20use%20the%20real%20server%20tracker%E2%80%99s%20pairing%20decision%20instead%20of%20sending%20a%20fresh%20tracker%20entry%20to%20every%20viewer.%0A%0A%281%20more%20issue%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=modl-gg%2Fminecraft&pr=15&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 5 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 5
platforms/fabric-121/src/main/java/gg/modl/minecraft/fabric/v1_21_1/handler/FabricStaffModeHandler.java:195-206
**Unconditional tracker pairing**

`unvanish()` calls this for every online player, but this new vanilla-packet path sends player-list and tracker pairing data without checking that the viewer is in the same world or inside the normal tracking range. If a vanished staff member unvanishes in another dimension or far away, this can spawn a ghost player entity for viewers who vanilla tracking would not pair with at all. Gate this send through the same world/range conditions, or use the real server tracker’s pairing decision instead of sending a fresh tracker entry to every viewer.

### Issue 2 of 5
platforms/fabric-1214/src/main/java/gg/modl/minecraft/fabric/v1_21_4/handler/FabricStaffModeHandler.java:194-205
**Unconditional tracker pairing**

`unvanish()` calls this for every online player, but this new vanilla-packet path sends player-list and tracker pairing data without checking that the viewer is in the same world or inside the normal tracking range. If a vanished staff member unvanishes in another dimension or far away, this can spawn a ghost player entity for viewers who vanilla tracking would not pair with at all. Gate this send through the same world/range conditions, or use the real server tracker’s pairing decision instead of sending a fresh tracker entry to every viewer.

### Issue 3 of 5
platforms/fabric-1218/src/main/java/gg/modl/minecraft/fabric/v1_21_8/handler/FabricStaffModeHandler.java:195-208
**Unconditional tracker pairing**

`unvanish()` calls this for every online player, but this new vanilla-packet path sends player-list and tracker pairing data without checking that the viewer is in the same world or inside the normal tracking range. If a vanished staff member unvanishes in another dimension or far away, this can spawn a ghost player entity for viewers who vanilla tracking would not pair with at all. Gate this send through the same world/range conditions, or use the real server tracker’s pairing decision instead of sending a fresh tracker entry to every viewer.

### Issue 4 of 5
platforms/fabric-12111/src/main/java/gg/modl/minecraft/fabric/v1_21_11/handler/FabricStaffModeHandler.java:196-221
**Unconditional tracker pairing**

`unvanish()` calls this for every online player, but this new vanilla-packet path sends player-list and tracker pairing data without checking that the viewer is in the same world or inside the normal tracking range. If a vanished staff member unvanishes in another dimension or far away, this can spawn a ghost player entity for viewers who vanilla tracking would not pair with at all. Gate this send through the same world/range conditions, or use the real server tracker’s pairing decision instead of sending a fresh tracker entry to every viewer.

### Issue 5 of 5
platforms/fabric-26/src/main/java/gg/modl/minecraft/fabric/v26/handler/FabricStaffModeHandler.java:227-256
**Unconditional tracker pairing**

`unvanish()` calls this for every online player, but this new vanilla-packet path sends player-list and tracker pairing data without checking that the viewer is in the same world or inside the normal tracking range. If a vanished staff member unvanishes in another dimension or far away, this can spawn a ghost player entity for viewers who vanilla tracking would not pair with at all. Gate this send through the same world/range conditions, or use the real server tracker’s pairing decision instead of sending a fresh tracker entry to every viewer.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix unvanish skin layers and mod crashes..."](https://github.com/modl-gg/minecraft/commit/f91deab9c39e1abdd24e2bbd52a3fa0ff2d362de) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33621199)</sub>

> Greptile also left **5 inline comments** on this PR.

**Context used:**

- Rule used - THE CENTRAL RULE everything else serves: maintain ... ([source](https://app.greptile.com/review/custom-context?memory=21719055-65fa-440f-b434-eba8d358d917))

<!-- /greptile_comment -->