### PR TITLE
fix console permissions

### DIFF
--- a/core/src/main/java/gg/modl/minecraft/core/PluginLoader.java
+++ b/core/src/main/java/gg/modl/minecraft/core/PluginLoader.java
@@ -593,11 +593,11 @@ public class PluginLoader {
     }
 
     private void enforceCommandAccess(AnnotationList annotations, CommandActor actor) {
-        if (annotations.contains(PlayerOnly.class) && actor.uniqueId() == null) {
+        if (annotations.contains(PlayerOnly.class) && gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
             throw deny(localeManager.getMessage("general.players_only"));
         }
 
-        if (actor.uniqueId() == null) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
             return;
         }
 
@@ -631,3 +631,4 @@ public class PluginLoader {
         };
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/player/TicketCommandUtil.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/player/TicketCommandUtil.java
@@ -107,7 +107,7 @@ public class TicketCommandUtil {
 
     public void sendClickableTicketMessage(CommandActor actor, Platform platform, LocaleManager localeManager,
                                             String message, String ticketUrl, String ticketId) {
-        if (actor.uniqueId() == null) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
             actor.reply(localeManager.getMessage("messages.console_ticket_url", mapOf("message", message, "url", ticketUrl)));
             return;
         }
@@ -134,3 +134,4 @@ public class TicketCommandUtil {
                    .replace("\t", "\\t");
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/AltsCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/AltsCommand.java
@@ -43,7 +43,7 @@ public class AltsCommand {
         int page = Pagination.parsePrintFlags(flags);
         boolean printMode = page > 0;
 
-        if (actor.uniqueId() == null || printMode) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor) || printMode) {
             printAlts(actor, playerQuery, Math.max(1, page));
             return;
         }
@@ -137,3 +137,4 @@ public class AltsCommand {
     }
 
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ChatCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ChatCommand.java
@@ -48,7 +48,7 @@ public class ChatCommand {
             return;
         }
 
-        if (actor.uniqueId() == null) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
             actor.reply(localeManager.getMessage("general.players_only"));
             return;
         }
@@ -144,14 +144,15 @@ public class ChatCommand {
     }
 
     private String getInGameName(CommandActor actor) {
-        if (actor.uniqueId() == null) return "Console";
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) return "Console";
         AbstractPlayer player = platform.getPlayer(actor.uniqueId());
         return player != null ? player.getUsername() : "Staff";
     }
 
     private String getPanelName(CommandActor actor, String fallback) {
-        if (actor.uniqueId() == null) return "Console";
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) return "Console";
         String display = cache.getStaffDisplayName(actor.uniqueId());
         return display != null ? display : fallback;
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/FreezeCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/FreezeCommand.java
@@ -66,14 +66,15 @@ public class FreezeCommand {
     }
 
     private String getInGameName(CommandActor actor) {
-        if (actor.uniqueId() == null) return "Console";
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) return "Console";
         AbstractPlayer player = platform.getPlayer(actor.uniqueId());
         return player != null ? player.getName() : "Staff";
     }
 
     private String getPanelName(CommandActor actor, String fallback) {
-        if (actor.uniqueId() == null) return "Console";
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) return "Console";
         String display = cache.getStaffDisplayName(actor.uniqueId());
         return display != null ? display : fallback;
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/HistoryCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/HistoryCommand.java
@@ -44,7 +44,7 @@ public class HistoryCommand {
         int page = Pagination.parsePrintFlags(flags);
         boolean printMode = page > 0;
 
-        if (actor.uniqueId() == null || printMode) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor) || printMode) {
             printHistory(actor, playerQuery, Math.max(1, page));
             return;
         }
@@ -169,3 +169,4 @@ public class HistoryCommand {
     }
 
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java
@@ -71,7 +71,7 @@ public class InspectCommand {
 
         boolean printMode = flags.equalsIgnoreCase("-p") || flags.equalsIgnoreCase("print");
 
-        if (actor.uniqueId() == null || printMode) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor) || printMode) {
             printLookup(actor, playerQuery);
             return;
         }
@@ -324,3 +324,4 @@ public class InspectCommand {
     }
 
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InterceptNetworkChatCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InterceptNetworkChatCommand.java
@@ -21,7 +21,7 @@ public class InterceptNetworkChatCommand {
 
     @Description("Toggle network chat interception")
     public void toggle(CommandActor actor) {
-        if (actor.uniqueId() == null) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
             actor.reply(localeManager.getMessage("general.players_only"));
             return;
         }
@@ -37,3 +37,4 @@ public class InterceptNetworkChatCommand {
         else actor.reply(localeManager.getMessage("intercept_chat.disabled"));
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/NotesCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/NotesCommand.java
@@ -39,7 +39,7 @@ public class NotesCommand {
         int page = Pagination.parsePrintFlags(flags);
         boolean printMode = page > 0;
 
-        if (actor.uniqueId() == null || printMode) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor) || printMode) {
             printNotes(actor, playerQuery, Math.max(1, page));
             return;
         }
@@ -113,3 +113,4 @@ public class NotesCommand {
     }
 
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/PunishmentActionCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/PunishmentActionCommand.java
@@ -36,7 +36,7 @@ public class PunishmentActionCommand {
     @Command("punishment_action")
     @StaffOnly
     public void punishmentAction(CommandActor actor, String action, String punishmentId) {
-        if (actor.uniqueId() == null) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
             actor.reply(localeManager.getMessage("general.gui_requires_player"));
             return;
         }
@@ -150,3 +150,4 @@ public class PunishmentActionCommand {
         });
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ReplayCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ReplayCommand.java
@@ -119,7 +119,7 @@ public class ReplayCommand {
 
     private UUID resolveTargetUuid(CommandActor actor, String targetName) {
         if (targetName == null || targetName.isEmpty()) {
-            if (actor.uniqueId() == null) {
+            if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
                 actor.reply(localeManager.getMessage("replay.console_specify_player"));
                 return null;
             }
@@ -140,3 +140,4 @@ public class ReplayCommand {
         return fallback != null && !fallback.isEmpty() ? fallback : uuid.toString();
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ReportsCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ReportsCommand.java
@@ -63,7 +63,7 @@ public class ReportsCommand {
             return;
         }
 
-        if (actor.uniqueId() == null) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
             if (actualPlayerQuery != null && !actualPlayerQuery.isEmpty()) {
                 printPlayerReports(actor, actualPlayerQuery, Math.max(1, page));
             } else actor.reply(localeManager.getMessage("general.invalid_syntax"));
@@ -198,3 +198,4 @@ public class ReportsCommand {
     }
 
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/StaffChatCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/StaffChatCommand.java
@@ -38,7 +38,7 @@ public class StaffChatCommand {
             return;
         }
 
-        if (actor.uniqueId() == null) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
             actor.reply(localeManager.getMessage("general.players_only"));
             return;
         }
@@ -51,7 +51,7 @@ public class StaffChatCommand {
     }
 
     private void sendStaffChatMessage(CommandActor actor, String message) {
-        if (actor.uniqueId() == null) {
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
             platform.staffBroadcast(staffChatConfig.formatMessage("Console", "Console", message));
             return;
         }
@@ -65,3 +65,4 @@ public class StaffChatCommand {
         platform.staffBroadcast(staffChatConfig.formatMessage(inGameName, panelName, message));
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/StaffListCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/StaffListCommand.java
@@ -42,7 +42,7 @@ public class StaffListCommand {
         int page = flag != null ? Pagination.parsePrintFlags(flag) : 0;
         boolean printMode = page > 0;
 
-        if (printMode || actor.uniqueId() == null) {
+        if (printMode || gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
             printStaffList(actor, Math.max(1, page));
             return;
         }
@@ -124,3 +124,4 @@ public class StaffListCommand {
         private final boolean vanished;
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/StaffModeCommand.java
+++ b/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/StaffModeCommand.java
@@ -69,14 +69,15 @@ public class StaffModeCommand {
     }
 
     private String getInGameName(CommandActor actor) {
-        if (actor.uniqueId() == null) return "Console";
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) return "Console";
         AbstractPlayer player = platform.getPlayer(actor.uniqueId());
         return player != null ? player.getName() : "Staff";
     }
 
     private String getPanelName(CommandActor actor, String fallback) {
-        if (actor.uniqueId() == null) return "Console";
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) return "Console";
         String display = cache.getStaffDisplayName(actor.uniqueId());
         return display != null ? display : fallback;
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/util/CommandUtil.java
+++ b/core/src/main/java/gg/modl/minecraft/core/util/CommandUtil.java
@@ -12,25 +12,42 @@ import java.util.UUID;
 import static gg.modl.minecraft.core.util.Java8Collections.*;
 
 public final class CommandUtil {
-    private CommandUtil() {}
+    public static final UUID CONSOLE_UUID = new UUID(0, 0);
+
+    private CommandUtil() {
+    }
+
+    public static boolean isConsole(CommandActor actor) {
+        return isConsole(actor.uniqueId());
+    }
+
+    public static boolean isConsole(UUID uuid) {
+        return uuid == null || CONSOLE_UUID.equals(uuid);
+    }
 
     public static String resolveActorName(CommandActor actor, Cache cache, Platform platform) {
-        if (actor.uniqueId() == null) return "Console";
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor))
+            return "Console";
         String panelName = cache.getStaffDisplayName(actor.uniqueId());
-        if (panelName != null) return panelName;
-        return platform.getAbstractPlayer(actor.uniqueId(), false).getUsername();
+        if (panelName != null)
+            return panelName;
+        AbstractPlayer player = platform.getAbstractPlayer(actor.uniqueId(), false);
+        return player != null ? player.getUsername() : actor.name();
     }
 
     public static String resolveActorId(CommandActor actor, Cache cache) {
-        if (actor.uniqueId() == null) return null;
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor))
+            return null;
         return cache.getStaffId(actor.uniqueId());
     }
 
     public static String resolveSenderName(UUID uuid, Cache cache, Platform platform) {
         String name = cache.getStaffDisplayName(uuid);
-        if (name != null) return name;
+        if (name != null)
+            return name;
         AbstractPlayer player = platform.getPlayer(uuid);
-        if (player != null) return player.getUsername();
+        if (player != null)
+            return player.getUsername();
         return "Staff";
     }
 
@@ -42,14 +59,17 @@ public final class CommandUtil {
         return handleException(actor, throwable, localeManager, "player_lookup.error");
     }
 
-    public static Void handleException(CommandActor actor, Throwable throwable, LocaleManager localeManager, String errorKey) {
+    public static Void handleException(CommandActor actor, Throwable throwable, LocaleManager localeManager,
+            String errorKey) {
         Throwable cause = throwable.getCause() != null ? throwable.getCause() : throwable;
         if (cause instanceof PanelUnavailableException) {
             actor.reply(localeManager.getMessage("api_errors.panel_restarting"));
         } else {
             actor.reply(localeManager.getMessage(errorKey,
-                    mapOf("error", localeManager.sanitizeErrorMessage(cause.getMessage() != null ? cause.getMessage() : "Unknown error"))));
+                    mapOf("error", localeManager
+                            .sanitizeErrorMessage(cause.getMessage() != null ? cause.getMessage() : "Unknown error"))));
         }
         return null;
     }
 }
+

--- a/core/src/main/java/gg/modl/minecraft/core/util/PermissionUtil.java
+++ b/core/src/main/java/gg/modl/minecraft/core/util/PermissionUtil.java
@@ -10,12 +10,12 @@ import java.util.UUID;
 public final class PermissionUtil {
     private PermissionUtil() {}
     public static boolean hasPermission(CommandActor actor, Cache cache, String permission) {
-        if (actor.uniqueId() == null) return true;
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) return true;
         return cache.hasPermission(actor.uniqueId(), permission);
     }
 
     public static boolean hasAnyPermission(CommandActor actor, Cache cache, String... permissions) {
-        if (actor.uniqueId() == null) return true;
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) return true;
         for (String permission : permissions) {
             if (hasPermission(actor, cache, permission)) return true;
         }
@@ -23,13 +23,13 @@ public final class PermissionUtil {
     }
 
     public static SyncResponse.ActiveStaffMember getStaffMember(CommandActor actor, Cache cache) {
-        if (actor.uniqueId() == null) return null;
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) return null;
         CachedProfile profile = cache.getPlayerProfile(actor.uniqueId());
         return profile != null ? profile.getStaffMember() : null;
     }
 
     public static boolean isStaff(CommandActor actor, Cache cache) {
-        if (actor.uniqueId() == null) return false;
+        if (gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) return false;
         return isStaff(actor.uniqueId(), cache);
     }
 
@@ -44,3 +44,4 @@ public final class PermissionUtil {
         return "punishment.apply." + punishmentTypeName.toLowerCase().replace(" ", "-");
     }
 }
+


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Confidence Score: 2/5</h3>

These issues should be fixed before merging.

- The central permission gate can grant console-level access based only on an all-zero UUID.
- Print-capable console commands can still be rejected before their fallback code runs.
- Several async link and metadata paths still use null-only UUID checks and misroute console output.

Focus on `PluginLoader.java`, `CommandUtil.java`, and the changed command files that still call `actor.uniqueId() != null`.

<details open><summary><h3>Security Review</h3></summary>

- **Permission bypass in `PluginLoader.enforceCommandAccess`**: actors with the nil UUID are treated as console and skip staff/admin/permission checks without a trusted sender-type check.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| core/src/main/java/gg/modl/minecraft/core/PluginLoader.java | Central command access now treats nil UUID actors as console before permission checks. |
| core/src/main/java/gg/modl/minecraft/core/util/CommandUtil.java | Console detection now depends on either null UUID or the all-zero UUID. |
| core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java | Initial console checks were updated, but later async link/action paths still use null-only UUID checks. |
| core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ReplayCommand.java | Replay target resolution uses the new console check, but successful capture link delivery does not. |
| core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/FreezeCommand.java | Freeze display names use the new console check, but bridge metadata still treats nil UUID as a staff player. |

</details>



<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ReplayCommand.java`, line 88-101 ([link](https://github.com/modl-gg/minecraft/blob/eaefe2c7d0e6c728c97ef8a5cc79067c12d12a86/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ReplayCommand.java#L88-L101)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Replay links disappear**

   This success path still uses `actor.uniqueId() != null` to choose between player JSON and the console fallback. With the new console definition, a nil-UUID console actor enters the player branch and sends the replay link to UUID `00000000-0000-0000-0000-000000000000`, so the console never receives the URL even though the capture succeeded.

   **Rule Used:** THE CENTRAL RULE everything else serves: maintain ... ([source](https://app.greptile.com/review/custom-context?memory=21719055-65fa-440f-b434-eba8d358d917))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ReplayCommand.java
   Line: 88-101
   
   Comment:
   **Replay links disappear**
   
   This success path still uses `actor.uniqueId() != null` to choose between player JSON and the console fallback. With the new console definition, a nil-UUID console actor enters the player branch and sends the replay link to UUID `00000000-0000-0000-0000-000000000000`, so the console never receives the URL even though the capture succeeded.
   
   
   
   **Rule Used:** THE CENTRAL RULE everything else serves: maintain ... ([source](https://app.greptile.com/review/custom-context?memory=21719055-65fa-440f-b434-eba8d358d917))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Fcore%2Fimpl%2Fcommands%2Fstaff%2FReplayCommand.java%0ALine%3A%2088-101%0A%0AComment%3A%0A**Replay%20links%20disappear**%0A%0AThis%20success%20path%20still%20uses%20%60actor.uniqueId%28%29%20!%3D%20null%60%20to%20choose%20between%20player%20JSON%20and%20the%20console%20fallback.%20With%20the%20new%20console%20definition%2C%20a%20nil-UUID%20console%20actor%20enters%20the%20player%20branch%20and%20sends%20the%20replay%20link%20to%20UUID%20%6000000000-0000-0000-0000-000000000000%60%2C%20so%20the%20console%20never%20receives%20the%20URL%20even%20though%20the%20capture%20succeeded.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28!gg.modl.minecraft.core.util.CommandUtil.isConsole%28actor%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20String%20clickText%20%3D%20localeManager.getMessage%28%22replay.click_to_view%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20String%20hoverText%20%3D%20localeManager.getMessage%28%22replay.click_to_view_hover%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20String%20json%20%3D%20String.format%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%7B%5C%22text%5C%22%3A%5C%22%5C%22%2C%5C%22extra%5C%22%3A%5B%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22%7B%5C%22text%5C%22%3A%5C%22%5C%22%2C%5C%22color%5C%22%3A%5C%22gold%5C%22%7D%2C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22%7B%5C%22text%5C%22%3A%5C%22%25s%5C%22%2C%5C%22color%5C%22%3A%5C%22aqua%5C%22%2C%5C%22underlined%5C%22%3Atrue%2C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22%5C%22clickEvent%5C%22%3A%7B%5C%22action%5C%22%3A%5C%22open_url%5C%22%2C%5C%22value%5C%22%3A%5C%22%25s%5C%22%7D%2C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22%5C%22hoverEvent%5C%22%3A%7B%5C%22action%5C%22%3A%5C%22show_text%5C%22%2C%5C%22value%5C%22%3A%5C%22%25s%5C%22%7D%7D%5D%7D%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20clickText.replace%28%22%5C%22%22%2C%20%22%5C%5C%5C%22%22%29%2C%20replayLink%2C%20hoverText.replace%28%22%5C%22%22%2C%20%22%5C%5C%5C%22%22%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20platform.runOnMainThread%28%28%29%20-%3E%20platform.sendJsonMessage%28actor.uniqueId%28%29%2C%20json%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20actor.reply%28localeManager.getMessage%28%22replay.capture_link%22%2C%20mapOf%28%22url%22%2C%20replayLink%29%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20THE%20CENTRAL%20RULE%20everything%20else%20serves%3A%20maintain%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D21719055-65fa-440f-b434-eba8d358d917%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modl-gg%2Fminecraft&pr=16&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

2. `core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java`, line 164-168 ([link](https://github.com/modl-gg/minecraft/blob/eaefe2c7d0e6c728c97ef8a5cc79067c12d12a86/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java#L164-L168)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Console actions misrouted**

   The punishment detail print path still treats every non-null UUID as a player. A console actor using the new nil UUID reaches this branch and sends punishment action controls to UUID `00000000-0000-0000-0000-000000000000` instead of keeping the console on the text-only path. Those controls are then invisible to the command sender.

   **Rule Used:** THE CENTRAL RULE everything else serves: maintain ... ([source](https://app.greptile.com/review/custom-context?memory=21719055-65fa-440f-b434-eba8d358d917))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java
   Line: 164-168
   
   Comment:
   **Console actions misrouted**
   
   The punishment detail print path still treats every non-null UUID as a player. A console actor using the new nil UUID reaches this branch and sends punishment action controls to UUID `00000000-0000-0000-0000-000000000000` instead of keeping the console on the text-only path. Those controls are then invisible to the command sender.
   
   
   
   **Rule Used:** THE CENTRAL RULE everything else serves: maintain ... ([source](https://app.greptile.com/review/custom-context?memory=21719055-65fa-440f-b434-eba8d358d917))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Fcore%2Fimpl%2Fcommands%2Fstaff%2FInspectCommand.java%0ALine%3A%20164-168%0A%0AComment%3A%0A**Console%20actions%20misrouted**%0A%0AThe%20punishment%20detail%20print%20path%20still%20treats%20every%20non-null%20UUID%20as%20a%20player.%20A%20console%20actor%20using%20the%20new%20nil%20UUID%20reaches%20this%20branch%20and%20sends%20punishment%20action%20controls%20to%20UUID%20%6000000000-0000-0000-0000-000000000000%60%20instead%20of%20keeping%20the%20console%20on%20the%20text-only%20path.%20Those%20controls%20are%20then%20invisible%20to%20the%20command%20sender.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20%28!gg.modl.minecraft.core.util.CommandUtil.isConsole%28actor%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20UUID%20senderUuid%20%3D%20actor.uniqueId%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20platform.runOnMainThread%28%28%29%20-%3E%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20PunishmentActionMessages.sendPunishmentActions%28platform%2C%20senderUuid%2C%20punishmentId%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20THE%20CENTRAL%20RULE%20everything%20else%20serves%3A%20maintain%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D21719055-65fa-440f-b434-eba8d358d917%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modl-gg%2Fminecraft&pr=16&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

3. `core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java`, line 311-317 ([link](https://github.com/modl-gg/minecraft/blob/eaefe2c7d0e6c728c97ef8a5cc79067c12d12a86/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java#L311-L317)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Console profile link lost**

   This branch still uses `actor.uniqueId() != null` to decide whether to send a clickable profile link or print the URL. With the new nil-UUID console representation, console enters the player branch and `sendJsonMessage` targets UUID `00000000-0000-0000-0000-000000000000`, so the console does not get the profile fallback URL.

   **Rule Used:** THE CENTRAL RULE everything else serves: maintain ... ([source](https://app.greptile.com/review/custom-context?memory=21719055-65fa-440f-b434-eba8d358d917))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java
   Line: 311-317
   
   Comment:
   **Console profile link lost**
   
   This branch still uses `actor.uniqueId() != null` to decide whether to send a clickable profile link or print the URL. With the new nil-UUID console representation, console enters the player branch and `sendJsonMessage` targets UUID `00000000-0000-0000-0000-000000000000`, so the console does not get the profile fallback URL.
   
   
   
   **Rule Used:** THE CENTRAL RULE everything else serves: maintain ... ([source](https://app.greptile.com/review/custom-context?memory=21719055-65fa-440f-b434-eba8d358d917))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Fcore%2Fimpl%2Fcommands%2Fstaff%2FInspectCommand.java%0ALine%3A%20311-317%0A%0AComment%3A%0A**Console%20profile%20link%20lost**%0A%0AThis%20branch%20still%20uses%20%60actor.uniqueId%28%29%20!%3D%20null%60%20to%20decide%20whether%20to%20send%20a%20clickable%20profile%20link%20or%20print%20the%20URL.%20With%20the%20new%20nil-UUID%20console%20representation%2C%20console%20enters%20the%20player%20branch%20and%20%60sendJsonMessage%60%20targets%20UUID%20%6000000000-0000-0000-0000-000000000000%60%2C%20so%20the%20console%20does%20not%20get%20the%20profile%20fallback%20URL.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20if%20%28!gg.modl.minecraft.core.util.CommandUtil.isConsole%28actor%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20String%20profileMessage%20%3D%20String.format%28PROFILE_LINK_JSON%2C%20profileUrl%2C%20playerName%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20UUID%20senderUuid%20%3D%20actor.uniqueId%28%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20platform.runOnMainThread%28%28%29%20-%3E%20platform.sendJsonMessage%28senderUuid%2C%20profileMessage%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20actor.reply%28localeManager.getMessage%28%22print.inspect.profile_fallback%22%2C%20mapOf%28%22url%22%2C%20profileUrl%29%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A**Rule%20Used%3A**%20THE%20CENTRAL%20RULE%20everything%20else%20serves%3A%20maintain%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D21719055-65fa-440f-b434-eba8d358d917%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modl-gg%2Fminecraft&pr=16&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>

4. `core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/FreezeCommand.java`, line 58-65 ([link](https://github.com/modl-gg/minecraft/blob/eaefe2c7d0e6c728c97ef8a5cc79067c12d12a86/core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/FreezeCommand.java#L58-L65)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Console freeze misattributed**

   The display-name helpers now classify the nil UUID as console, but the freeze metadata still only checks for `null`. When console is represented as `00000000-0000-0000-0000-000000000000`, this sends that UUID over the bridge as the staff UUID instead of the empty console marker used by the old null-console path. Downstream freeze handling can then resolve or store the action as a fake player UUID rather than console.

   **Rule Used:** THE CENTRAL RULE everything else serves: maintain ... ([source](https://app.greptile.com/review/custom-context?memory=21719055-65fa-440f-b434-eba8d358d917))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/FreezeCommand.java
   Line: 58-65
   
   Comment:
   **Console freeze misattributed**
   
   The display-name helpers now classify the nil UUID as console, but the freeze metadata still only checks for `null`. When console is represented as `00000000-0000-0000-0000-000000000000`, this sends that UUID over the bridge as the staff UUID instead of the empty console marker used by the old null-console path. Downstream freeze handling can then resolve or store the action as a fake player UUID rather than console.
   
   
   
   **Rule Used:** THE CENTRAL RULE everything else serves: maintain ... ([source](https://app.greptile.com/review/custom-context?memory=21719055-65fa-440f-b434-eba8d358d917))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20core%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Fcore%2Fimpl%2Fcommands%2Fstaff%2FFreezeCommand.java%0ALine%3A%2058-65%0A%0AComment%3A%0A**Console%20freeze%20misattributed**%0A%0AThe%20display-name%20helpers%20now%20classify%20the%20nil%20UUID%20as%20console%2C%20but%20the%20freeze%20metadata%20still%20only%20checks%20for%20%60null%60.%20When%20console%20is%20represented%20as%20%6000000000-0000-0000-0000-000000000000%60%2C%20this%20sends%20that%20UUID%20over%20the%20bridge%20as%20the%20staff%20UUID%20instead%20of%20the%20empty%20console%20marker%20used%20by%20the%20old%20null-console%20path.%20Downstream%20freeze%20handling%20can%20then%20resolve%20or%20store%20the%20action%20as%20a%20fake%20player%20UUID%20rather%20than%20console.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20UUID%20staffUuid%20%3D%20gg.modl.minecraft.core.util.CommandUtil.isConsole%28actor%29%20%3F%20null%20%3A%20actor.uniqueId%28%29%3B%0A%20%20%20%20%20%20%20%20freezeService.freeze%28targetUuid%2C%20staffUuid%29%3B%0A%20%20%20%20%20%20%20%20platform.staffBroadcast%28localeManager.getMessage%28%22freeze.staff_notification_freeze%22%2C%20mapOf%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22player%22%2C%20targetName%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22staff%22%2C%20panelName%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22in-game-name%22%2C%20inGameName%0A%20%20%20%20%20%20%20%20%29%29%29%3B%0A%20%20%20%20%20%20%20%20bridgeService.sendFreezePlayer%28targetUuid.toString%28%29%2C%20staffUuid%20!%3D%20null%20%3F%20staffUuid.toString%28%29%20%3A%20%22%22%29%3B%0A%60%60%60%0A%0A**Rule%20Used%3A**%20THE%20CENTRAL%20RULE%20everything%20else%20serves%3A%20maintain%20...%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D21719055-65fa-440f-b434-eba8d358d917%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=modl-gg%2Fminecraft&pr=16&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%206%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%206%0Acore%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Fcore%2FPluginLoader.java%3A600-602%0A**Nil%20UUID%20bypasses%20permissions**%0A%0AThis%20branch%20treats%20any%20actor%20with%20%6000000000-0000-0000-0000-000000000000%60%20as%20console%20and%20returns%20before%20%60%40StaffOnly%60%2C%20%60%40AdminOnly%60%2C%20and%20%60%40RequiresPermission%60%20are%20checked.%20If%20a%20player%20or%20platform%20command%20actor%20is%20ever%20represented%20with%20that%20UUID%2C%20non-player-only%20commands%20run%20with%20full%20console%20permissions%20instead%20of%20the%20player's%20cached%20permissions.%20The%20console%20check%20needs%20to%20be%20tied%20to%20the%20sender%20type%20or%20another%20trusted%20adapter%20signal%2C%20not%20only%20the%20UUID%20value.%0A%0A%23%23%23%20Issue%202%20of%206%0Acore%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Fcore%2FPluginLoader.java%3A596-598%0A**Console%20print%20paths%20blocked**%0A%0ASeveral%20%60%40PlayerOnly%60%20commands%20in%20this%20PR%20now%20contain%20explicit%20console%20print%20fallbacks%2C%20such%20as%20%60alts%60%2C%20%60history%60%2C%20%60inspect%60%2C%20%60notes%60%2C%20and%20%60reports%60.%20This%20command%20condition%20runs%20first%2C%20so%20a%20console%20represented%20by%20the%20new%20nil%20UUID%20is%20rejected%20here%20before%20those%20fallback%20branches%20can%20run.%20That%20leaves%20the%20console%20unable%20to%20use%20the%20print-capable%20flows%20this%20change%20is%20trying%20to%20support.%0A%0A%23%23%23%20Issue%203%20of%206%0Acore%2Fsrc%2Fmain%2Fjava%2Fgg%2Fmodl%2Fminecraft%2Fcore%2Fimpl%2Fcommands%2Fstaff%2FReplayCommand.java%3A88-101%0A**Replay%20links%20disappear**%0A%0AThis%20success%20path%20still%20uses%20%60actor.uniqueId%28%29%20!%3D%20null%60%20to%20choose%20between%20player%20JSON%20and%20the%20console%20fallback.%20With%20the%20new%20console%20definition%2C%20a%20nil-UUID%20console%20actor%20enters%20the%20player%20branch%20and%20sends%20the%20replay%20link%20to%20UUID%20%6000000000-0000-0000-0000-000000000000%60%2C%20so%20the%20console%20never%20receives%20the%20URL%20even%20though%20the%20capture%20succeeded.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20if%20%28!gg.modl.minecraft.core.util.CommandUtil.isConsole%28actor%29%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20String%20clickText%20%3D%20localeManager.getMessage%28%22replay.click_to_view%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20String%20hoverText%20%3D%20localeManager.getMessage%28%22replay.click_to_view_hover%22%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20String%20json%20%3D%20String.format%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%22%7B%5C%22text%5C%22%3A%5C%22%5C%22%2C%5C%22extra%5C%22%3A%5B%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22%7B%5C%22text%5C%22%3A%5C%22%5C%22%2C%5C%22color%5C%22%3A%5C%22gold%5C%22%7D%2C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22%7B%5C%22text%5C%22%3A%5C%22%25s%5C%22%2C%5C%22color%5C%22%3A%5C%22aqua%5C%22%2C%5C%22underlined%5C%22%3Atrue%2C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22%5C%22clickEvent%5C%22%3A%7B%5C%22action%5C%22%3A%5C%22open_url%5C%22%2C%5C%22value%5C%22%3A%5C%22%25s%5C%22%7D%2C%22%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%2B%20%22%5C%22hoverEvent%5C%22%3A%7B%5C%22action%5C%22%3A%5C%22show_text%5C%22%2C%5C%22value%5C%22%3A%5C%22%25s%5C%22%7D%7D%5D%7D%22%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20clickText.replace%28%22%5C%22%22%2C%20%22%5C%5C%5C%22%22%29%2C%20replayLink%2C%20hoverText.replace%28%22%5C%22%22%2C%20%22%5C%5C%5C%22%22%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20platform.runOnMainThread%28%28%29%20-%3E%20platform.sendJsonMessage%28actor.uniqueId%28%29%2C%20json%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20actor.reply%28localeManager.getMessage%28%22replay.capture_link%22%2C%20mapOf%28%22url%22%2C%20replayLink%29%29%29%3B%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%0A%60%60%60%0A%0A%283%20more%20issues%20omitted%20due%20to%20length%20limits.%20Use%20individual%20%22Fix%20in%20Claude%20Code%22%20links%20for%20remaining%20issues.%29%0A&repo=modl-gg%2Fminecraft&pr=16&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 6 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 6
core/src/main/java/gg/modl/minecraft/core/PluginLoader.java:600-602
**Nil UUID bypasses permissions**

This branch treats any actor with `00000000-0000-0000-0000-000000000000` as console and returns before `@StaffOnly`, `@AdminOnly`, and `@RequiresPermission` are checked. If a player or platform command actor is ever represented with that UUID, non-player-only commands run with full console permissions instead of the player's cached permissions. The console check needs to be tied to the sender type or another trusted adapter signal, not only the UUID value.

### Issue 2 of 6
core/src/main/java/gg/modl/minecraft/core/PluginLoader.java:596-598
**Console print paths blocked**

Several `@PlayerOnly` commands in this PR now contain explicit console print fallbacks, such as `alts`, `history`, `inspect`, `notes`, and `reports`. This command condition runs first, so a console represented by the new nil UUID is rejected here before those fallback branches can run. That leaves the console unable to use the print-capable flows this change is trying to support.

### Issue 3 of 6
core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/ReplayCommand.java:88-101
**Replay links disappear**

This success path still uses `actor.uniqueId() != null` to choose between player JSON and the console fallback. With the new console definition, a nil-UUID console actor enters the player branch and sends the replay link to UUID `00000000-0000-0000-0000-000000000000`, so the console never receives the URL even though the capture succeeded.

```suggestion
                if (!gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
                    String clickText = localeManager.getMessage("replay.click_to_view");
                    String hoverText = localeManager.getMessage("replay.click_to_view_hover");
                    String json = String.format(
                            "{\"text\":\"\",\"extra\":["
                            + "{\"text\":\"\",\"color\":\"gold\"},"
                            + "{\"text\":\"%s\",\"color\":\"aqua\",\"underlined\":true,"
                            + "\"clickEvent\":{\"action\":\"open_url\",\"value\":\"%s\"},"
                            + "\"hoverEvent\":{\"action\":\"show_text\",\"value\":\"%s\"}}]}",
                            clickText.replace("\"", "\\\""), replayLink, hoverText.replace("\"", "\\\""));
                    platform.runOnMainThread(() -> platform.sendJsonMessage(actor.uniqueId(), json));
                } else {
                    actor.reply(localeManager.getMessage("replay.capture_link", mapOf("url", replayLink)));
                }
```

### Issue 4 of 6
core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java:164-168
**Console actions misrouted**

The punishment detail print path still treats every non-null UUID as a player. A console actor using the new nil UUID reaches this branch and sends punishment action controls to UUID `00000000-0000-0000-0000-000000000000` instead of keeping the console on the text-only path. Those controls are then invisible to the command sender.

```suggestion
            if (!gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
                UUID senderUuid = actor.uniqueId();
                platform.runOnMainThread(() ->
                    PunishmentActionMessages.sendPunishmentActions(platform, senderUuid, punishmentId));
            }
```

### Issue 5 of 6
core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/InspectCommand.java:311-317
**Console profile link lost**

This branch still uses `actor.uniqueId() != null` to decide whether to send a clickable profile link or print the URL. With the new nil-UUID console representation, console enters the player branch and `sendJsonMessage` targets UUID `00000000-0000-0000-0000-000000000000`, so the console does not get the profile fallback URL.

```suggestion
            if (!gg.modl.minecraft.core.util.CommandUtil.isConsole(actor)) {
                String profileMessage = String.format(PROFILE_LINK_JSON, profileUrl, playerName);
                UUID senderUuid = actor.uniqueId();
                platform.runOnMainThread(() -> platform.sendJsonMessage(senderUuid, profileMessage));
            } else {
                actor.reply(localeManager.getMessage("print.inspect.profile_fallback", mapOf("url", profileUrl)));
            }
```

### Issue 6 of 6
core/src/main/java/gg/modl/minecraft/core/impl/commands/staff/FreezeCommand.java:58-65
**Console freeze misattributed**

The display-name helpers now classify the nil UUID as console, but the freeze metadata still only checks for `null`. When console is represented as `00000000-0000-0000-0000-000000000000`, this sends that UUID over the bridge as the staff UUID instead of the empty console marker used by the old null-console path. Downstream freeze handling can then resolve or store the action as a fake player UUID rather than console.

```suggestion
        UUID staffUuid = gg.modl.minecraft.core.util.CommandUtil.isConsole(actor) ? null : actor.uniqueId();
        freezeService.freeze(targetUuid, staffUuid);
        platform.staffBroadcast(localeManager.getMessage("freeze.staff_notification_freeze", mapOf(
                "player", targetName,
                "staff", panelName,
                "in-game-name", inGameName
        )));
        bridgeService.sendFreezePlayer(targetUuid.toString(), staffUuid != null ? staffUuid.toString() : "");
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix console permissions"](https://github.com/modl-gg/minecraft/commit/eaefe2c7d0e6c728c97ef8a5cc79067c12d12a86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33984977)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - THE CENTRAL RULE everything else serves: maintain ... ([source](https://app.greptile.com/review/custom-context?memory=21719055-65fa-440f-b434-eba8d358d917))

<!-- /greptile_comment -->